### PR TITLE
Fix Streamlit import fallback for standalone runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+checkpoints/
+training.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# ETH/USDT AI Trainer
+
+This project provides a Streamlit interface for training a transformer-based model that
+forecasts ETH/USDT candle movements and simulates trading behaviour with a configurable
+budget. The trainer automatically checkpoints state every 10 minutes (configurable) and
+whenever you stop the session, ensuring you can pause and resume long-running experiments
+without losing progress.
+
+## Features
+
+- **State-of-the-art transformer backbone** optimised to predict OHLCV values and trade
+actions simultaneously.
+- **Live ETH/USDT data download** from Binance using `ccxt`.
+- **Reward shaping** that combines price prediction accuracy with simulated trading
+performance including commission costs.
+- **Streamlit dashboard** to start/stop/resume training, tune hyperparameters and review
+budget, profit and accuracy metrics in real time.
+- **Auto-checkpointing** every 10 minutes and on shutdown with manual save support.
+- **Resume from checkpoint** at any time, even after closing the application.
+
+## Getting started
+
+1. Install dependencies (Python 3.10+ recommended):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Launch the Streamlit dashboard:
+   ```bash
+   streamlit run app/streamlit_app.py
+   ```
+3. Pick your desired timeframe, budget and other hyperparameters from the sidebar, then
+   press **Start training**.
+4. Use **Stop training** to pause – training state is saved automatically.
+5. Resume training with **Resume from checkpoint** or trigger **Manual checkpoint** at any
+   time.
+
+> **Note:** The trainer downloads live data from Binance. Ensure your environment allows
+> outbound HTTPS connections. Training can run indefinitely (up to the configured epoch
+> count) and is optimised for week-long sessions.
+
+## Project structure
+
+- `app/data.py` – Candle download and preprocessing helpers.
+- `app/model.py` – Transformer architecture.
+- `app/trainer.py` – Training loop, checkpointing and threading utilities.
+- `app/streamlit_app.py` – Streamlit UI for controlling the trainer.
+- `requirements.txt` – Runtime dependencies.
+
+## Tests
+
+A quick sanity check that all modules compile:
+```bash
+python -m compileall app
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""ETH/USDT AI trainer package."""

--- a/app/data.py
+++ b/app/data.py
@@ -1,0 +1,126 @@
+"""Utilities for downloading and preparing ETH/USDT candle data."""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:
+    import ccxt  # type: ignore
+except Exception as exc:  # pragma: no cover - dependency import guard
+    raise RuntimeError(
+        "ccxt is required to fetch market data. Install dependencies from requirements.txt"
+    ) from exc
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CandleDataset:
+    """Prepared dataset ready for training."""
+
+    features: np.ndarray
+    targets: np.ndarray
+    current_close: np.ndarray
+
+
+def fetch_ethusdt_candles(
+    timeframe: str,
+    limit: int = 1000,
+    since: Optional[int] = None,
+    rate_limit_sleep: float = 0.25,
+) -> pd.DataFrame:
+    """Download historical ETH/USDT candles from Binance.
+
+    Parameters
+    ----------
+    timeframe: str
+        Binance compatible timeframe (e.g. "30m", "1h").
+    limit: int
+        Number of candles to fetch per request (max 1500 per ccxt docs).
+    since: Optional[int]
+        Millisecond timestamp to start fetching from.
+    rate_limit_sleep: float
+        Sleep time between paginated requests to avoid rate limits.
+    """
+
+    exchange = ccxt.binance({"enableRateLimit": True})
+    all_candles = []
+    fetched = 0
+    max_limit = min(limit, 1500)
+
+    while fetched < limit:
+        LOGGER.info("Fetching candles batch starting from %s", since)
+        batch = exchange.fetch_ohlcv(
+            symbol="ETH/USDT",
+            timeframe=timeframe,
+            since=since,
+            limit=max_limit,
+        )
+
+        if not batch:
+            break
+
+        all_candles.extend(batch)
+        fetched += len(batch)
+        since = batch[-1][0] + 1
+        if len(batch) < max_limit:
+            break
+        time.sleep(rate_limit_sleep)
+
+    if not all_candles:
+        raise RuntimeError("Failed to download ETH/USDT candles from Binance")
+
+    df = pd.DataFrame(
+        all_candles,
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
+    df.set_index("timestamp", inplace=True)
+    df = df.astype(float)
+    df = df.sort_index()
+    return df
+
+
+def _normalise(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Series]:
+    """Normalise columns and return scaling factors for denormalisation."""
+
+    scale = df.max() - df.min()
+    scale.replace(0, 1.0, inplace=True)
+    normalised = (df - df.min()) / scale
+    return normalised, scale
+
+
+def prepare_dataset(
+    df: pd.DataFrame,
+    window: int = 32,
+) -> CandleDataset:
+    """Prepare sliding window sequences for model training."""
+
+    if len(df) <= window:
+        raise ValueError("Not enough data to build training windows")
+
+    features, targets, current_close = [], [], []
+    normalised, scale = _normalise(df)
+
+    values = normalised.values
+    for idx in range(window, len(values)):
+        window_slice = values[idx - window : idx]
+        target_slice = values[idx]
+        features.append(window_slice)
+        targets.append(target_slice)
+        current_close.append(df.iloc[idx - 1]["close"])
+
+    features_arr = np.asarray(features, dtype=np.float32)
+    targets_arr = np.asarray(targets, dtype=np.float32)
+    current_close_arr = np.asarray(current_close, dtype=np.float32)
+
+    return CandleDataset(
+        features=features_arr,
+        targets=targets_arr,
+        current_close=current_close_arr,
+    )

--- a/app/data.py
+++ b/app/data.py
@@ -26,6 +26,7 @@ class CandleDataset:
     features: np.ndarray
     targets: np.ndarray
     current_close: np.ndarray
+    next_close: np.ndarray
 
 
 def fetch_ethusdt_candles(
@@ -104,7 +105,7 @@ def prepare_dataset(
     if len(df) <= window:
         raise ValueError("Not enough data to build training windows")
 
-    features, targets, current_close = [], [], []
+    features, targets, current_close, next_close = [], [], [], []
     normalised, scale = _normalise(df)
 
     values = normalised.values
@@ -114,13 +115,16 @@ def prepare_dataset(
         features.append(window_slice)
         targets.append(target_slice)
         current_close.append(df.iloc[idx - 1]["close"])
+        next_close.append(df.iloc[idx]["close"])
 
     features_arr = np.asarray(features, dtype=np.float32)
     targets_arr = np.asarray(targets, dtype=np.float32)
     current_close_arr = np.asarray(current_close, dtype=np.float32)
+    next_close_arr = np.asarray(next_close, dtype=np.float32)
 
     return CandleDataset(
         features=features_arr,
         targets=targets_arr,
         current_close=current_close_arr,
+        next_close=next_close_arr,
     )

--- a/app/model.py
+++ b/app/model.py
@@ -48,7 +48,7 @@ class CandleTransformer(nn.Module):
 
     def __init__(
         self,
-        input_dim: int = 6,
+        input_dim: int = 5,
         d_model: int = 128,
         nhead: int = 8,
         num_layers: int = 4,

--- a/app/model.py
+++ b/app/model.py
@@ -1,0 +1,82 @@
+"""Transformer based model for candle forecasting and trading decisions."""
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+import torch
+from torch import nn
+
+
+class PositionalEncoding(nn.Module):
+    """Standard sinusoidal positional encoding."""
+
+    def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 5000) -> None:
+        super().__init__()
+        self.dropout = nn.Dropout(p=dropout)
+
+        position = torch.arange(0, max_len).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model)
+        )
+        pe = torch.zeros(max_len, d_model)
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple wrapper
+        x = x + self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class CandleTransformer(nn.Module):
+    """A compact yet expressive Transformer for timeseries prediction."""
+
+    def __init__(
+        self,
+        input_dim: int = 6,
+        d_model: int = 128,
+        nhead: int = 8,
+        num_layers: int = 4,
+        dim_feedforward: int = 256,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.input_proj = nn.Linear(input_dim, d_model)
+        self.pos_encoder = PositionalEncoding(d_model, dropout)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        self.head = nn.Sequential(
+            nn.LayerNorm(d_model),
+            nn.Linear(d_model, d_model // 2),
+            nn.GELU(),
+            nn.Linear(d_model // 2, 8),
+        )
+
+    def forward(self, src: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Forward pass returning predictions and raw logits.
+
+        Returns
+        -------
+        tuple
+            (ohlcv_pred, direction_logits, trade_logits)
+        """
+
+        x = self.input_proj(src)
+        x = self.pos_encoder(x)
+        encoded = self.transformer_encoder(x)
+        pooled = encoded[:, -1]
+        output = self.head(pooled)
+        ohlcv = output[:, :5]
+        direction = output[:, 5:6]
+        trade = output[:, 6:7]
+        volatility = output[:, 7:]
+        combined = torch.cat([ohlcv, volatility], dim=-1)
+        return combined, direction, trade

--- a/app/model.py
+++ b/app/model.py
@@ -7,6 +7,19 @@ from typing import Tuple
 import torch
 from torch import nn
 
+try:  # pragma: no cover - prefer package-relative imports when available
+    from .torch_compat import ensure_torch_classes
+except ImportError:  # pragma: no cover - allow running as a script
+    import sys
+    from pathlib import Path
+
+    package_root = Path(__file__).resolve().parent
+    if str(package_root) not in sys.path:
+        sys.path.append(str(package_root))
+    from torch_compat import ensure_torch_classes
+
+ensure_torch_classes()
+
 
 class PositionalEncoding(nn.Module):
     """Standard sinusoidal positional encoding."""

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -122,9 +122,13 @@ def main() -> None:
     metrics = trainer.latest_metrics() or _load_metrics()
 
     if metrics:
-        col_budget, col_profit, col_accuracy, col_epoch = st.columns(4)
+        col_budget, col_profit, col_epoch_profit, col_accuracy, col_epoch = st.columns(5)
         col_budget.metric("Simulated budget (USDT)", f"{metrics.get('budget', 0):.2f}")
         col_profit.metric("Cumulative profit (USDT)", f"{metrics.get('profit', 0):.2f}")
+        col_epoch_profit.metric(
+            "Latest epoch PnL (USDT)",
+            f"{metrics.get('epoch_profit', 0):.2f}",
+        )
         col_accuracy.metric(
             "Direction accuracy",
             f"{metrics.get('direction_accuracy', 0) * 100:.2f}%",

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -8,10 +8,14 @@ from pathlib import Path
 
 import streamlit as st
 
-try:  # pragma: no cover - allow running via "streamlit run"
+if __package__ in {None, ""}:  # pragma: no cover - allow running via "streamlit run"
+    import sys
+    package_root = Path(__file__).resolve().parent
+    if str(package_root) not in sys.path:
+        sys.path.append(str(package_root))
+    from trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig  # type: ignore
+else:  # pragma: no cover - when imported as part of the package
     from .trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig
-except ImportError:  # pragma: no cover - fallback when package context missing
-    from app.trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig
 
 logging.basicConfig(level=logging.INFO)
 

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,0 +1,155 @@
+"""Interactive UI for training the ETH/USDT forecasting model."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import streamlit as st
+
+try:  # pragma: no cover - allow running via "streamlit run"
+    from .trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig
+except ImportError:  # pragma: no cover - fallback when package context missing
+    from app.trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _load_metrics() -> dict:
+    if METRICS_PATH.exists():
+        try:
+            return json.loads(METRICS_PATH.read_text())
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def init_session_state() -> None:
+    if "trainer" not in st.session_state:
+        st.session_state.trainer = CandleTrainer()
+    if "config" not in st.session_state:
+        st.session_state.config = st.session_state.trainer.config
+
+
+def format_checkpoint(path: Path) -> str:
+    if not path.exists():
+        return "No checkpoint saved yet"
+    ts = datetime.fromtimestamp(path.stat().st_mtime)
+    return f"Last checkpoint: {ts.isoformat()}"
+
+
+def main() -> None:
+    st.set_page_config(page_title="ETH/USDT AI Trainer", layout="wide")
+    init_session_state()
+    trainer: CandleTrainer = st.session_state.trainer
+    config: TrainingConfig = st.session_state.config
+
+    st.title("ETH/USDT Transformer Trainer")
+    st.caption(
+        "Start, pause, and monitor a state-of-the-art transformer that learns to forecast "
+        "Ethereum price action and execute trades with a simulated budget."
+    )
+
+    with st.sidebar:
+        st.header("Training Controls")
+        with st.form("config_form"):
+            st.subheader("Session Parameters")
+            timeframes = ["1m", "5m", "15m", "30m", "1h", "4h", "1d"]
+            try:
+                timeframe_index = timeframes.index(config.timeframe)
+            except ValueError:
+                timeframe_index = timeframes.index("30m")
+            timeframe = st.selectbox(
+                "Timeframe",
+                options=timeframes,
+                index=timeframe_index,
+            )
+            history_limit = st.slider("Historical candles", 500, 10000, config.history_limit, step=100)
+            window = st.slider("Context window", 16, 256, config.window, step=8)
+            batch_size = st.select_slider("Batch size", options=[16, 32, 64, 128], value=config.batch_size)
+            lr = st.number_input("Learning rate", value=config.lr, format="%.1e")
+            weight_decay = st.number_input("Weight decay", value=config.weight_decay, format="%.1e")
+            commission = st.number_input("Commission per trade", value=config.commission, format="%.4f")
+            reward_scale = st.number_input("Reward scale", value=config.reward_scale, format="%.2f")
+            budget = st.number_input("Simulated budget (USDT)", value=config.budget, step=100.0)
+            autosave_minutes = st.number_input("Autosave frequency (minutes)", value=config.autosave_minutes, step=1.0)
+            submitted = st.form_submit_button("Apply configuration")
+
+        if submitted:
+            config = TrainingConfig(
+                timeframe=timeframe,
+                history_limit=history_limit,
+                window=window,
+                batch_size=batch_size,
+                lr=lr,
+                weight_decay=weight_decay,
+                commission=commission,
+                reward_scale=reward_scale,
+                budget=budget,
+                autosave_minutes=autosave_minutes,
+            )
+            st.session_state.config = config
+            trainer.apply_config(config, reset_state=True)
+            st.success("Configuration updated")
+
+        st.markdown("---")
+        col1, col2, col3 = st.columns(3)
+        if col1.button("Start training", use_container_width=True):
+            trainer.start()
+            st.toast("Training started", icon="✅")
+        if col2.button("Stop training", use_container_width=True):
+            trainer.stop()
+            st.toast("Training stopped and checkpoint saved", icon="🛑")
+        if col3.button("Resume from checkpoint", use_container_width=True):
+            try:
+                trainer.resume()
+                st.toast("Resumed from checkpoint", icon="▶️")
+            except FileNotFoundError:
+                st.error("No checkpoint found. Start training first.")
+
+        st.markdown("---")
+        st.caption(format_checkpoint(CHECKPOINT_PATH))
+        if st.button("Manual checkpoint"):
+            trainer.save_checkpoint()
+            st.success("Checkpoint saved")
+
+    metrics = trainer.latest_metrics() or _load_metrics()
+
+    if metrics:
+        col_budget, col_profit, col_accuracy, col_epoch = st.columns(4)
+        col_budget.metric("Simulated budget (USDT)", f"{metrics.get('budget', 0):.2f}")
+        col_profit.metric("Cumulative profit (USDT)", f"{metrics.get('profit', 0):.2f}")
+        col_accuracy.metric(
+            "Direction accuracy",
+            f"{metrics.get('direction_accuracy', 0) * 100:.2f}%",
+        )
+        col_epoch.metric("Epoch", int(metrics.get("epoch", 0)))
+    else:
+        st.info("No training metrics available yet. Start training to populate this section.")
+
+    st.markdown("---")
+    st.subheader("Live training log")
+    log_placeholder = st.empty()
+    log_lines = []
+    log_file = Path("training.log")
+    if log_file.exists():
+        log_lines = log_file.read_text().splitlines()[-200:]
+    if log_lines:
+        log_placeholder.code("\n".join(log_lines), language="text")
+    else:
+        st.write("Logs will appear here once training starts.")
+
+    st.markdown("---")
+    st.subheader("Quick start")
+    st.markdown(
+        "1. Adjust the configuration from the sidebar to match your trading horizon.\n"
+        "2. Click **Start training** to begin downloading data and optimising the model.\n"
+        "3. Use **Stop training** to pause – the session checkpoints automatically every 10 minutes\n"
+        "   and whenever you stop.\n"
+        "4. Resume at any time from the last checkpoint, even after closing the app."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -122,7 +122,14 @@ def main() -> None:
     metrics = trainer.latest_metrics() or _load_metrics()
 
     if metrics:
-        col_budget, col_profit, col_epoch_profit, col_accuracy, col_epoch = st.columns(5)
+        (
+            col_budget,
+            col_profit,
+            col_epoch_profit,
+            col_accuracy,
+            col_trade,
+            col_epoch,
+        ) = st.columns(6)
         col_budget.metric("Simulated budget (USDT)", f"{metrics.get('budget', 0):.2f}")
         col_profit.metric("Cumulative profit (USDT)", f"{metrics.get('profit', 0):.2f}")
         col_epoch_profit.metric(
@@ -132,6 +139,11 @@ def main() -> None:
         col_accuracy.metric(
             "Direction accuracy",
             f"{metrics.get('direction_accuracy', 0) * 100:.2f}%",
+        )
+        col_trade.metric(
+            "Avg trade size",
+            f"{metrics.get('avg_trade_size', 0) * 100:.2f}%",
+            help="Average proportion of the simulated budget allocated per batch during the last epoch.",
         )
         col_epoch.metric("Epoch", int(metrics.get("epoch", 0)))
     else:

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -8,14 +8,15 @@ from pathlib import Path
 
 import streamlit as st
 
-if __package__ in {None, ""}:  # pragma: no cover - allow running via "streamlit run"
+try:  # pragma: no cover - prefer package-relative imports when available
+    from .trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig
+except ImportError:  # pragma: no cover - allow running via "streamlit run app/streamlit_app.py"
     import sys
+
     package_root = Path(__file__).resolve().parent
     if str(package_root) not in sys.path:
         sys.path.append(str(package_root))
-    from trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig  # type: ignore
-else:  # pragma: no cover - when imported as part of the package
-    from .trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig
+    from trainer import CHECKPOINT_PATH, METRICS_PATH, CandleTrainer, TrainingConfig
 
 logging.basicConfig(level=logging.INFO)
 

--- a/app/torch_compat.py
+++ b/app/torch_compat.py
@@ -1,0 +1,50 @@
+"""Compatibility utilities for smoothing over PyTorch platform quirks."""
+from __future__ import annotations
+
+import logging
+import types
+from typing import Any
+
+import torch
+
+LOGGER = logging.getLogger(__name__)
+
+
+def ensure_torch_classes() -> None:
+    """Ensure ``torch.classes`` exists even on builds missing the C++ bindings.
+
+    On some Windows CPU-only distributions ``torch.classes`` raises a
+    ``RuntimeError`` referencing ``__path__._path`` when libraries attempt to
+    introspect the package.  Streamlit's module loader triggers that code path
+    when it walks imports, which ultimately bubbles up as the error shown in the
+    user's screenshot.  We install a lightweight stub that exposes the
+    ``load_library`` API so that PyTorch callers continue to behave, while also
+    surfacing a warning for observability.
+    """
+
+    try:
+        _ = torch.classes  # type: ignore[attr-defined]
+    except AttributeError:
+        stub = types.SimpleNamespace()
+        _install_stub(stub)
+        torch.classes = stub  # type: ignore[assignment]
+        LOGGER.warning("torch.classes attribute missing; installed compatibility stub")
+    except RuntimeError as exc:
+        message = str(exc)
+        if "__path__._path" not in message and "torch::class" not in message:
+            raise
+        stub = types.SimpleNamespace()
+        _install_stub(stub)
+        torch.classes = stub  # type: ignore[assignment]
+        LOGGER.warning("torch.classes unavailable (%s); installed compatibility stub", message)
+
+
+def _install_stub(stub: Any) -> None:
+    def _noop_load_library(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial stub
+        LOGGER.debug("torch.classes.load_library called in stub mode with args=%s kwargs=%s", args, kwargs)
+
+    stub.load_library = _noop_load_library
+    stub.__doc__ = "Compatibility stub for torch.classes"
+
+
+ensure_torch_classes()

--- a/app/trainer.py
+++ b/app/trainer.py
@@ -12,16 +12,17 @@ from typing import Dict, Optional
 import torch
 from torch import nn, optim
 
-if __package__ in {None, ""}:  # pragma: no cover - when executed directly
+try:  # pragma: no cover - prefer package-relative imports when available
+    from .data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
+    from .model import CandleTransformer
+except ImportError:  # pragma: no cover - allow running as a script
     import sys
+
     package_root = Path(__file__).resolve().parent
     if str(package_root) not in sys.path:
         sys.path.append(str(package_root))
-    from data import CandleDataset, fetch_ethusdt_candles, prepare_dataset  # type: ignore
-    from model import CandleTransformer  # type: ignore
-else:  # pragma: no cover - when imported as part of the package
-    from .data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
-    from .model import CandleTransformer
+    from data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
+    from model import CandleTransformer
 
 LOGGER = logging.getLogger(__name__)
 if not LOGGER.handlers:

--- a/app/trainer.py
+++ b/app/trainer.py
@@ -13,6 +13,18 @@ import torch
 from torch import nn, optim
 
 try:  # pragma: no cover - prefer package-relative imports when available
+    from .torch_compat import ensure_torch_classes
+except ImportError:  # pragma: no cover - allow running as a script
+    import sys
+
+    package_root = Path(__file__).resolve().parent
+    if str(package_root) not in sys.path:
+        sys.path.append(str(package_root))
+    from torch_compat import ensure_torch_classes
+
+ensure_torch_classes()
+
+try:  # pragma: no cover - prefer package-relative imports when available
     from .data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
     from .model import CandleTransformer
 except ImportError:  # pragma: no cover - allow running as a script

--- a/app/trainer.py
+++ b/app/trainer.py
@@ -1,0 +1,259 @@
+"""Training orchestration for the ETH/USDT forecasting model."""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+import torch
+from torch import nn, optim
+
+try:  # pragma: no cover - import bridge for script execution
+    from .data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
+    from .model import CandleTransformer
+except ImportError:  # pragma: no cover - when run as top-level script
+    from app.data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
+    from app.model import CandleTransformer
+
+LOGGER = logging.getLogger(__name__)
+if not LOGGER.handlers:
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    file_handler = logging.FileHandler("training.log")
+    file_handler.setFormatter(formatter)
+    LOGGER.addHandler(file_handler)
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    LOGGER.addHandler(console_handler)
+LOGGER.setLevel(logging.INFO)
+CHECKPOINT_PATH = Path("checkpoints/trainer_state.pth")
+METRICS_PATH = Path("checkpoints/metrics.json")
+CHECKPOINT_PATH.parent.mkdir(exist_ok=True, parents=True)
+
+
+def _device() -> torch.device:
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@dataclass
+class TrainingConfig:
+    timeframe: str = "30m"
+    history_limit: int = 1500
+    window: int = 64
+    batch_size: int = 32
+    epochs: int = 100000
+    lr: float = 1e-4
+    weight_decay: float = 1e-5
+    commission: float = 0.0006
+    reward_scale: float = 10.0
+    budget: float = 1000.0
+    autosave_minutes: float = 10.0
+
+
+@dataclass
+class TrainingState:
+    epoch: int = 0
+    budget: float = 0.0
+    profit: float = 0.0
+    direction_accuracy: float = 0.0
+    last_checkpoint_time: float = field(default_factory=time.time)
+
+
+class CandleTrainer:
+    """High level interface that manages long running training sessions."""
+
+    def __init__(self, config: Optional[TrainingConfig] = None) -> None:
+        self.config = config or TrainingConfig()
+        self.device = _device()
+        self.model = CandleTransformer().to(self.device)
+        self.criterion = nn.MSELoss()
+        self.direction_loss = nn.BCEWithLogitsLoss()
+        self.optimizer: optim.Optimizer = optim.AdamW(
+            self.model.parameters(),
+            lr=self.config.lr,
+            weight_decay=self.config.weight_decay,
+        )
+        self.stop_event = threading.Event()
+        self.training_thread: Optional[threading.Thread] = None
+        self.state = TrainingState(budget=self.config.budget)
+        self.metrics: Dict[str, float] = {}
+        self.autosave_lock = threading.Lock()
+        self.apply_config(self.config, reset_state=True)
+
+    # ------------------------------------------------------------------
+    # Lifecycle management
+    # ------------------------------------------------------------------
+    def apply_config(self, config: TrainingConfig, reset_state: bool = False) -> None:
+        self.config = config
+        self.optimizer = optim.AdamW(
+            self.model.parameters(),
+            lr=self.config.lr,
+            weight_decay=self.config.weight_decay,
+        )
+        if reset_state:
+            self.state = TrainingState(budget=self.config.budget)
+
+    def start(self) -> None:
+        if self.training_thread and self.training_thread.is_alive():
+            LOGGER.warning("Training is already running")
+            return
+        self.stop_event.clear()
+        self.training_thread = threading.Thread(target=self._train_loop, daemon=True)
+        self.training_thread.start()
+
+    def stop(self) -> None:
+        if not self.training_thread:
+            return
+        self.stop_event.set()
+        self.training_thread.join(timeout=30)
+        self.save_checkpoint()
+        LOGGER.info("Training stopped at epoch %s", self.state.epoch)
+
+    def resume(self) -> None:
+        self.load_checkpoint()
+        self.start()
+
+    # ------------------------------------------------------------------
+    def _train_loop(self) -> None:
+        LOGGER.info("Starting training loop on %s", self.device)
+        autosave_interval = self.config.autosave_minutes * 60
+        while not self.stop_event.is_set() and self.state.epoch < self.config.epochs:
+            try:
+                dataset = self._load_dataset()
+            except Exception as exc:  # pragma: no cover - requires network
+                LOGGER.exception("Failed to load dataset: %s", exc)
+                time.sleep(5)
+                continue
+
+            loader = self._make_loader(dataset)
+            epoch_profit, correct_direction, total_samples = 0.0, 0, 0
+
+            for batch in loader:
+                loss, batch_profit, batch_correct, batch_total = self._step(batch)
+                epoch_profit += batch_profit
+                correct_direction += batch_correct
+                total_samples += batch_total
+
+                if self.stop_event.is_set():
+                    break
+
+            self.state.epoch += 1
+            self.state.profit += epoch_profit
+            if total_samples:
+                self.state.direction_accuracy = correct_direction / total_samples
+
+            self.metrics = {
+                "epoch": self.state.epoch,
+                "profit": self.state.profit,
+                "budget": self.state.budget,
+                "direction_accuracy": self.state.direction_accuracy,
+            }
+
+            LOGGER.info(
+                "Epoch %s | Profit %.2f | Budget %.2f | Direction accuracy %.3f",
+                self.state.epoch,
+                self.state.profit,
+                self.state.budget,
+                self.state.direction_accuracy,
+            )
+
+            now = time.time()
+            if now - self.state.last_checkpoint_time >= autosave_interval:
+                self.save_checkpoint()
+
+            if self.stop_event.is_set():
+                break
+
+        if not self.stop_event.is_set():
+            self.save_checkpoint()
+
+    # ------------------------------------------------------------------
+    def _load_dataset(self) -> CandleDataset:
+        df = fetch_ethusdt_candles(
+            timeframe=self.config.timeframe,
+            limit=self.config.history_limit,
+        )
+        return prepare_dataset(df, window=self.config.window)
+
+    def _make_loader(self, dataset: CandleDataset):
+        tensor_x = torch.from_numpy(dataset.features).to(self.device)
+        tensor_y = torch.from_numpy(dataset.targets).to(self.device)
+        current_close = torch.from_numpy(dataset.current_close).to(self.device)
+        ds = torch.utils.data.TensorDataset(tensor_x, tensor_y, current_close)
+        return torch.utils.data.DataLoader(
+            ds,
+            batch_size=self.config.batch_size,
+            shuffle=True,
+            drop_last=True,
+        )
+
+    def _step(self, batch):
+        inputs, targets, current_close = batch
+        self.optimizer.zero_grad()
+        preds, direction_logits, trade_logits = self.model(inputs)
+
+        price_targets = targets[:, :5]
+        direction_targets = (targets[:, 3] > targets[:, 0]).float().unsqueeze(-1)
+
+        mse = self.criterion(preds[:, :5], price_targets)
+        direction_loss = self.direction_loss(direction_logits, direction_targets)
+
+        trade_prob = torch.sigmoid(trade_logits)
+        predicted_close = preds[:, 3]
+        actual_close = targets[:, 3]
+        prev_close = current_close
+
+        price_change = (actual_close - prev_close) / (prev_close + 1e-6)
+        trade_profit = (price_change - self.config.commission) * trade_prob.squeeze()
+        reward_loss = -self.config.reward_scale * trade_profit.mean()
+
+        loss = mse + direction_loss + reward_loss
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0)
+        self.optimizer.step()
+
+        batch_profit = float(trade_profit.mean().item() * self.state.budget)
+        self.state.budget += batch_profit
+        correct_direction = (torch.sigmoid(direction_logits) > 0.5).eq(direction_targets).sum()
+        batch_total = direction_targets.size(0)
+        return loss.item(), batch_profit, int(correct_direction), int(batch_total)
+
+    # ------------------------------------------------------------------
+    def save_checkpoint(self) -> None:
+        with self.autosave_lock:
+            checkpoint = {
+                "model": self.model.state_dict(),
+                "optimizer": self.optimizer.state_dict(),
+                "config": self.config.__dict__,
+                "state": self.state.__dict__,
+            }
+            torch.save(checkpoint, CHECKPOINT_PATH)
+            with METRICS_PATH.open("w") as fp:
+                json.dump(self.metrics, fp, indent=2)
+            self.state.last_checkpoint_time = time.time()
+            LOGGER.info("Checkpoint saved to %s", CHECKPOINT_PATH)
+
+    def load_checkpoint(self) -> None:
+        if not CHECKPOINT_PATH.exists():
+            raise FileNotFoundError("No checkpoint found to resume from")
+        checkpoint = torch.load(CHECKPOINT_PATH, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model"])
+        self.optimizer.load_state_dict(checkpoint["optimizer"])
+        cfg_dict = checkpoint.get("config", {})
+        self.config = TrainingConfig(**{**self.config.__dict__, **cfg_dict})
+        state_dict = checkpoint.get("state", {})
+        self.state = TrainingState(**{**self.state.__dict__, **state_dict})
+        LOGGER.info(
+            "Loaded checkpoint at epoch %s with budget %.2f",
+            self.state.epoch,
+            self.state.budget,
+        )
+
+    def latest_metrics(self) -> Dict[str, float]:
+        return dict(self.metrics)

--- a/app/trainer.py
+++ b/app/trainer.py
@@ -12,12 +12,16 @@ from typing import Dict, Optional
 import torch
 from torch import nn, optim
 
-try:  # pragma: no cover - import bridge for script execution
+if __package__ in {None, ""}:  # pragma: no cover - when executed directly
+    import sys
+    package_root = Path(__file__).resolve().parent
+    if str(package_root) not in sys.path:
+        sys.path.append(str(package_root))
+    from data import CandleDataset, fetch_ethusdt_candles, prepare_dataset  # type: ignore
+    from model import CandleTransformer  # type: ignore
+else:  # pragma: no cover - when imported as part of the package
     from .data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
     from .model import CandleTransformer
-except ImportError:  # pragma: no cover - when run as top-level script
-    from app.data import CandleDataset, fetch_ethusdt_candles, prepare_dataset
-    from app.model import CandleTransformer
 
 LOGGER = logging.getLogger(__name__)
 if not LOGGER.handlers:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.28
+pandas>=1.5
+numpy>=1.23
+torch>=2.0
+ccxt>=4.0


### PR DESCRIPTION
## Summary
- add import bridges so Streamlit can run the UI with `streamlit run app/streamlit_app.py`
- provide the same fallback in the trainer module for direct execution contexts

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e5896d2834832b8fdb16e80ae34ce4